### PR TITLE
Default sync values to empty strings

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -63,11 +63,11 @@ Menu.prototype.addLocalSite = function (hostname) {
     var self = this;
 
     chrome.storage.sync.get({
-        local_sites: [],
-        live_sites: []
+        local_sites: '',
+        live_sites: ''
     }, function (items) {
-        var live = items.live_sites.split("\n");
-        var local = items.local_sites.split("\n");
+        var live = items.live_sites.length === 0 ? [] : items.live_sites.split("\n");
+        var local = items.local_sites.length === 0 ? [] : items.local_sites.split("\n");
 
         if (local.indexOf(hostname) === -1) {
             local.push(hostname);
@@ -90,11 +90,11 @@ Menu.prototype.addLiveSite = function (hostname) {
     var self = this;
 
     chrome.storage.sync.get({
-        local_sites: [],
-        live_sites: []
+        local_sites: '',
+        live_sites: ''
     }, function (items) {
-        var live = items.live_sites.split("\n");
-        var local = items.local_sites.split("\n");
+        var live = items.live_sites.length === 0 ? [] : items.live_sites.split("\n");
+        var local = items.local_sites.length === 0 ? [] : items.local_sites.split("\n");
 
         if (live.indexOf(hostname) === -1) {
             live.push(hostname);
@@ -117,11 +117,11 @@ Menu.prototype.removeSite = function (hostname) {
     var self = this;
 
     chrome.storage.sync.get({
-        live_sites: [],
-        local_sites: []
+        live_sites: '',
+        local_sites: ''
     }, function (items) {
-        var live = items.live_sites.split("\n");
-        var local = items.local_sites.split("\n");
+        var live = items.live_sites.length === 0 ? [] : items.live_sites.split("\n");
+        var local = items.local_sites.length === 0 ? [] : items.local_sites.split("\n");
 
         live = live.filter(function (site) {
             return site != hostname;


### PR DESCRIPTION
Since the functions expect string values, they should default to empty strings. And since an array with one empty value is returned when splitting a string with a delimiter, we should make sure make sure there's a value before splitting.

As it's currently written, you can't use the extension until you manually populate the textareas via the Options page, because a JS error happens if you use the buttons.

To test repeatedly I had to call `chrome.storage.sync.clear()` between tests to clear out values.